### PR TITLE
Added AliasProperty and tests

### DIFF
--- a/pydispatch/dispatch.py
+++ b/pydispatch/dispatch.py
@@ -83,19 +83,12 @@ class Dispatcher(object):
     __initialized_subclasses = set()
     __skip_initialized = True
     def __new__(cls, *args, **kwargs):
-        def iter_bases(_cls):
-            if _cls is not object:
-                yield _cls
-                for b in _cls.__bases__:
-                    for _cls_ in iter_bases(b):
-                        yield _cls_
         skip_initialized = Dispatcher._Dispatcher__skip_initialized
         if not skip_initialized or cls not in Dispatcher._Dispatcher__initialized_subclasses:
             props = {}
             events = set()
-            for _cls in iter_bases(cls):
-                for attr in dir(_cls):
-                    prop = getattr(_cls, attr)
+            for _cls in cls.__mro__:
+                for attr, prop in _cls.__dict__.items():
                     if attr not in props and isinstance(prop, Property):
                         props[attr] = prop
                         prop.name = attr

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,10 +1,15 @@
-
 def test_properties(listener):
-    from pydispatch import Dispatcher, Property
+    from pydispatch import Dispatcher, Property, AliasProperty
     class A(Dispatcher):
         test_prop = Property('default')
         name = Property('')
         something = Property()
+
+        def get_name_something(self):
+            return '{} {}'.format(self.name, self.something)
+
+        name_something = AliasProperty(get_name_something, bind=('name', 'something'))
+
         def __init__(self, name):
             self.name = name
             self.something = 'stuff'
@@ -12,6 +17,7 @@ def test_properties(listener):
     a = A('foo')
     assert a.something == 'stuff'
     assert a.name == 'foo'
+    assert a.name_something == 'foo stuff'
     a.bind(test_prop=listener.on_prop)
 
     assert 'test_prop' in a._Dispatcher__property_events
@@ -23,11 +29,12 @@ def test_properties(listener):
     a.test_prop = 'b'
     assert listener.property_events == ['a', 'b']
 
+
 def test_container_properties(listener):
     from pydispatch import Dispatcher, ListProperty, DictProperty
 
     class A(Dispatcher):
-        test_dict = DictProperty({'defaultkey':'defaultval'})
+        test_dict = DictProperty({'defaultkey': 'defaultval'})
         test_list = ListProperty(['defaultitem'])
 
     a = A()
@@ -36,17 +43,17 @@ def test_container_properties(listener):
     assert a.test_dict['defaultkey'] == 'defaultval'
     assert a.test_list[0] == 'defaultitem'
 
-    a.test_dict = {'changed':True}
+    a.test_dict = {'changed': True}
     a.test_list = ['changed']
 
     assert a.test_dict['changed'] is True and len(a.test_dict) == 1
     assert a.test_list[0] == 'changed' and len(a.test_list) == 1
 
-    assert listener.property_events == [{'changed':True}, ['changed']]
+    assert listener.property_events == [{'changed': True}, ['changed']]
 
     listener.property_events = []
     listener.property_event_kwargs = []
-    a.test_dict['nested_dict'] = {'foo':'bar'}
+    a.test_dict['nested_dict'] = {'foo': 'bar'}
     a.test_dict['nested_dict']['foo'] = 'baz'
     a.test_dict['nested_dict']['nested_list'] = [0]
     a.test_dict['nested_dict']['nested_list'].append(1)
@@ -57,12 +64,12 @@ def test_container_properties(listener):
 
     listener.property_events = []
 
-    a.test_list.append({'nested_dict':{'foo':'bar'}})
+    a.test_list.append({'nested_dict': {'foo': 'bar'}})
     d = a.test_list[-1]
     d['nested_dict']['foo'] = 'baz'
 
     assert len(listener.property_events) == 2
-    assert a.test_list[-1] == {'nested_dict':{'foo':'baz'}}
+    assert a.test_list[-1] == {'nested_dict': {'foo': 'baz'}}
 
     listener.property_events = []
     del a.test_list[:]
@@ -75,6 +82,7 @@ def test_container_properties(listener):
         a.test_list.clear()
         a.test_list.append(True)
         assert len(listener.property_events) == 3
+
 
 def test_list_property_ops(listener):
     from pydispatch import Dispatcher, ListProperty
@@ -119,11 +127,12 @@ def test_list_property_ops(listener):
     assert a.test_list == ['a', 'b', 'c', 'd', 'e', 'f', 'g']
     assert len(listener.property_events) == 2
 
+
 def test_dict_property_ops(listener):
     from pydispatch import Dispatcher, DictProperty
 
     class A(Dispatcher):
-        test_dict = DictProperty({'a':1, 'b':2, 'c':3, 'd':4})
+        test_dict = DictProperty({'a': 1, 'b': 2, 'c': 3, 'd': 4})
 
     a = A()
     a.bind(test_dict=listener.on_prop)
@@ -139,9 +148,9 @@ def test_dict_property_ops(listener):
 
     listener.property_events = []
     listener.property_event_kwargs = []
-    a.test_dict.update({'c':3, 'e':5, 'f':6, 'g':7})
+    a.test_dict.update({'c': 3, 'e': 5, 'f': 6, 'g': 7})
     assert len(listener.property_events) == 1
-    assert a.test_dict == {'c':3, 'd':4, 'e':5, 'f':6, 'g':7}
+    assert a.test_dict == {'c': 3, 'd': 4, 'e': 5, 'f': 6, 'g': 7}
     assert sorted(listener.property_event_kwargs[0]['keys']) == ['e', 'f', 'g']
 
     listener.property_events = []
@@ -153,6 +162,7 @@ def test_dict_property_ops(listener):
     a.test_dict.setdefault('foo', 'bar')
     assert len(listener.property_events) == 1
     assert a.test_dict['foo'] == 'bar'
+
 
 def test_empty_defaults(listener):
     from pydispatch import Dispatcher, ListProperty, DictProperty
@@ -176,10 +186,12 @@ def test_empty_defaults(listener):
 
     assert len(listener.property_events) == 2
 
+
 def test_unbind(listener):
     from pydispatch import Dispatcher, Property
     class A(Dispatcher):
         test_prop = Property()
+
     a = A()
     a.bind(test_prop=listener.on_prop)
 
@@ -205,12 +217,14 @@ def test_unbind(listener):
     a.test_prop = 4
     assert len(listener.property_events) == 0
 
+
 def test_removal():
     from pydispatch import Dispatcher, Property
 
     class Listener(object):
         def __init__(self):
             self.property_events = []
+
         def on_prop(self, obj, value, **kwargs):
             self.property_events.append(value)
 
@@ -235,6 +249,7 @@ def test_removal():
     assert len(prop._Property__weakrefs) == 0
     assert len(prop._Property__storage) == 0
 
+
 def test_self_binding():
     from pydispatch import Dispatcher, Property, ListProperty, DictProperty
 
@@ -242,6 +257,7 @@ def test_self_binding():
         test_prop = Property()
         test_dict = DictProperty()
         test_list = ListProperty()
+
         def __init__(self):
             self.received = []
             self.bind(
@@ -249,10 +265,13 @@ def test_self_binding():
                 test_dict=self.on_test_dict,
                 test_list=self.on_test_list,
             )
+
         def on_test_prop(self, *args, **kwargs):
             self.received.append('test_prop')
+
         def on_test_dict(self, *args, **kwargs):
             self.received.append('test_dict')
+
         def on_test_list(self, *args, **kwargs):
             self.received.append('test_list')
 
@@ -263,6 +282,7 @@ def test_self_binding():
     a.test_list.append('baz')
 
     assert a.received == ['test_prop', 'test_dict', 'test_list']
+
 
 def test_emission_lock(listener):
     from pydispatch import Dispatcher, Property, ListProperty, DictProperty
@@ -279,7 +299,7 @@ def test_emission_lock(listener):
 
     a.test_prop = 'foo'
     a.test_list = [-1] * 4
-    a.test_dict = {'a':0, 'b':1, 'c':2, 'd':3}
+    a.test_dict = {'a': 0, 'b': 1, 'c': 2, 'd': 3}
 
     assert len(listener.property_events) == 3
     listener.property_events = []
@@ -320,7 +340,7 @@ def test_emission_lock(listener):
     assert listener.property_event_kwargs[1]['property'].name == 'test_list'
     assert listener.property_events[1][0] == 'a'
     assert listener.property_event_kwargs[2]['property'].name == 'test_dict'
-    assert listener.property_events[2] == {k:i for k in a.test_dict.keys()}
+    assert listener.property_events[2] == {k: i for k in a.test_dict.keys()}
 
     listener.property_events = []
     listener.property_event_kwargs = []
@@ -341,6 +361,7 @@ def test_emission_lock(listener):
     assert listener.property_event_kwargs[2]['property'].name == 'test_prop'
     assert listener.property_events[2] == i
 
+
 def test_copy_on_change(listener):
     from pydispatch import Dispatcher, ListProperty, DictProperty
 
@@ -360,22 +381,22 @@ def test_copy_on_change(listener):
     assert listener.property_event_kwargs[0]['old'] == {}
 
     a.test_dict['foo'] = None
-    assert listener.property_event_kwargs[1]['old'] == {'foo':'bar'}
+    assert listener.property_event_kwargs[1]['old'] == {'foo': 'bar'}
 
-    a.test_dict['nested_dict'] = {'a':1}
-    assert listener.property_event_kwargs[2]['old'] == {'foo':None}
+    a.test_dict['nested_dict'] = {'a': 1}
+    assert listener.property_event_kwargs[2]['old'] == {'foo': None}
 
     a.test_dict['nested_dict']['b'] = 2
-    assert listener.property_event_kwargs[3]['old'] == {'foo':None, 'nested_dict':{'a':1}}
+    assert listener.property_event_kwargs[3]['old'] == {'foo': None, 'nested_dict': {'a': 1}}
 
     a.test_dict['nested_list'] = ['a', 'b']
     assert listener.property_event_kwargs[4]['old'] == {
-        'foo':None, 'nested_dict':{'a':1, 'b':2}
+        'foo': None, 'nested_dict': {'a': 1, 'b': 2}
     }
 
     a.test_dict['nested_list'].append('c')
     assert listener.property_event_kwargs[5]['old'] == {
-        'foo':None, 'nested_dict':{'a':1, 'b':2}, 'nested_list':['a', 'b']
+        'foo': None, 'nested_dict': {'a': 1, 'b': 2}, 'nested_list': ['a', 'b']
     }
 
     listener.property_event_kwargs = []
@@ -393,10 +414,10 @@ def test_copy_on_change(listener):
     assert listener.property_event_kwargs[3]['old'] == [{}, 'b', 'c']
 
     a.test_list[1] = [0]
-    assert listener.property_event_kwargs[4]['old'] == [{'foo':'bar'}, 'b', 'c']
+    assert listener.property_event_kwargs[4]['old'] == [{'foo': 'bar'}, 'b', 'c']
 
     a.test_list[1].append(1)
-    assert listener.property_event_kwargs[5]['old'] == [{'foo':'bar'}, [0], 'c']
+    assert listener.property_event_kwargs[5]['old'] == [{'foo': 'bar'}, [0], 'c']
 
     listener.property_event_kwargs = []
 


### PR DESCRIPTION
Added an `AliasProperty` similar to Kivy but without the `kv` language specific attributes. This required refactoring the `__new__` method of the `Dispatcher` class. The bind argument to AliasProperty requires properties to `_add_instance` in declaration order. The builtin `dir()` method doesn't list attributes in declaration order. Now the `__dict__` property of the class is used for detecting properties. I also changed the iteration of base classes to use the `__mro__` since that is the correct inheritance order already unraveled. 