### PR TITLE
Use importlib.metadata for runtime `__version__` detection

### DIFF
--- a/pydispatch/__init__.py
+++ b/pydispatch/__init__.py
@@ -1,9 +1,12 @@
 import sys
 import warnings
-import pkg_resources
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
 
 try:
-    __version__ = pkg_resources.require('python-dispatch')[0].version
+    __version__ = importlib_metadata.version('python-dispatch')
 except: # pragma: no cover
     __version__ = 'unknown'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,8 @@ license_file = LICENSE.txt
 keywords = event properties dispatch
 platforms = any
 python_requires = >=3.6
+install_requires =
+    importlib_metadata;python_version<'3.8'
 classifiers =
     Development Status :: 3 - Alpha
     Intended Audience :: Developers

--- a/tests/test_version_attribute.py
+++ b/tests/test_version_attribute.py
@@ -1,0 +1,18 @@
+
+from pathlib import Path
+from setuptools.config import read_configuration
+
+
+PROJECT_ROOT = Path(__file__).parent.parent.resolve()
+SETUP_CFG = PROJECT_ROOT / 'setup.cfg'
+
+def get_expected_version(config_file: Path = SETUP_CFG) -> str:
+    conf_dict = read_configuration(str(config_file))
+    return conf_dict['metadata']['version']
+
+EXPECTED_VERSION = get_expected_version()
+
+
+def test_version():
+    import pydispatch
+    assert pydispatch.__version__ == EXPECTED_VERSION


### PR DESCRIPTION
Remove implicit setuptools dependency

Fixes #19 